### PR TITLE
Fix tab indentation in haskell example

### DIFF
--- a/style/Haskell.md
+++ b/style/Haskell.md
@@ -115,9 +115,9 @@ indented by one level:
 ```
 let'sFold xs = do
     foldr
-	  (\x y -> ...)
-	  Nothing
-	  xs
+      (\x y -> ...)
+      Nothing
+      xs
 ```
 
 But consider naming the arguments instead to avoid multi-line

--- a/style/Haskell.md
+++ b/style/Haskell.md
@@ -112,7 +112,7 @@ If an application must spawn multiple lines to fit within the maximum
 line length, then write one argument on each line following the head,
 indented by one level:
 
-```
+```Haskell
 let'sFold xs = do
     foldr
       (\x y -> ...)


### PR DESCRIPTION
One of the examples about indentation in the style guide was using tabs, which github then rendered as 8 spaces.